### PR TITLE
Fix for Windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cexio"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Sergey Isaev <isvforall@gmail.com>"]
 edition = "2018"
 
@@ -23,7 +23,8 @@ include = [
 [dependencies]
 reqwest = { version = "0.10.1", features = ["blocking", "json"] }
 serde = { version = "1.0.104", features = ["derive"] }
-ring = "0.16.9"
+hmac = "0.7.1"
+sha2 = "0.8.1"
 hex = "0.4.0"
 strum_macros = "0.17.1"
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -123,59 +123,61 @@ pub struct ConvertResult {
     pub amnt: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct BTC {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct BCH {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct ETH {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct LTC {
     pub available: String,
     pub orders: String,
 }
-#[derive(Debug, Deserialize)]
+
+#[derive(Debug, Default, Deserialize)]
 pub struct DASH {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct ZEC {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct USD {
     pub available: String,
     pub orders: String,
 }
-#[derive(Debug, Deserialize)]
+
+#[derive(Debug, Default, Deserialize)]
 pub struct EUR {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct GBP {
     pub available: String,
     pub orders: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct RUB {
     pub available: String,
     pub orders: String,
@@ -185,16 +187,16 @@ pub struct RUB {
 pub struct BalanceResult {
     pub timestamp: String,
     pub username: String,
-    pub BTC: BTC,
-    pub BCH: BCH,
-    pub ETH: ETH,
-    pub LTC: LTC,
-    pub DASH: DASH,
-    pub ZEC: ZEC,
-    pub USD: USD,
-    pub EUR: EUR,
-    pub GBP: GBP,
-    pub RUB: RUB,
+    #[serde(default)]  pub BTC: BTC,
+    #[serde(default)]  pub BCH: BCH,
+    #[serde(default)]  pub ETH: ETH,
+    #[serde(default)]  pub LTC: LTC,
+    #[serde(default)]  pub DASH: DASH,
+    #[serde(default)]  pub ZEC: ZEC,
+    #[serde(default)]  pub USD: USD,
+    #[serde(default)]  pub EUR: EUR,
+    #[serde(default)]  pub GBP: GBP,
+    #[serde(default)]  pub RUB: RUB,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This PR adds 2 main fixes:

1. For some reason, ring 0.16.11, one of the dependencies, has trouble building on windows. Since only the HMAC feature of that library is used, it can be replaced with a smaller library (hmac and sha2)

2. Some Cex.io accounts don't have all the symbols enabled. Thus, some requests (to the /balance endpoint for example) don't return the full list of symbols in the json response. By adding a default value for the Symbols's structs, deserialization doesn't crash anymore.